### PR TITLE
Makefile内の記述をPOSIX互換な書き方に修正

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         os:
           - 'macos-latest'
+          - 'ubuntu-latest'
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: test
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os:
+          - 'macos-latest'
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install bats
+        run: npm install -g bats
+
+      - name: test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,12 @@ build:
 
 .PHONY:
 check:
-	@if [[ -z "$$TARGET_DIR" ]]; then\
+	@if [ -z "$(TARGET_DIR)" ]; then\
 	    echo 'TARGET_DIRの環境変数を設定してください';\
 	    echo 'ex: export TARGET_DIR=/Path/To/Target/Dir';\
 	    exit 1;\
 	else\
-		echo "TARGET_DIR: $${TARGET_DIR}";\
+		echo "TARGET_DIR: $(TARGET_DIR)";\
 	fi
 
 .PHONY:

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,7 @@ php-cs-fixer: check
 .PHONY:
 phpinsights: check
 	@docker run --rm -v ${TARGET_DIR}:/app:ro -v ${PWD}:/work php-metrics-tools phpinsights analyse --config-path=/work/config/phpinsights.php --ansi ./
+
+.PHONY:
+test:
+	bats tests/

--- a/tests/Makefile.bats
+++ b/tests/Makefile.bats
@@ -1,0 +1,10 @@
+setup() {
+    DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )"
+}
+
+@test "TARGET_DIRの環境変数が設定されていない場合エラーになること" {
+    run make check
+    [ "$status" -ne 0 ]
+    [[ "$output" =~ "TARGET_DIRの環境変数を設定してください" ]]
+    [[ "$output" =~ "ex: export TARGET_DIR=/Path/To/Target/Dir" ]]
+}


### PR DESCRIPTION
# 概要

- refs: #1

Ubuntu環境で動作確認いただいた際に、Makefileの `check` ターゲットの処理でエラーにならず、そのまま後続のコマンドが実行されてしまったとのご報告をいただいた。

手元でUbuntu環境を用意して実行してみると確かに意図した結果にならなかった。

```
ubuntu@ip-xxx-xx-xx-xxx:~/php-metrics-tools$ make check
/bin/sh: 1: [[: not found
TARGET_DIR:
```

Macの環境では動作しており、変数の参照箇所がPOSIX互換の書き方になっていなかったため該当箇所を修正した。

# 対応内容

コミットごとの対応内容。

## テストを追加(for Mac)

まずテストを追加。

- batsを利用することでテストを行う
    - https://bats-core.readthedocs.io/
    - https://github.com/bats-core/bats-core
- Makefileに `test` ターゲットを実装し `make test` でテストが実行できるようにした
- `make check` コマンド実行時に意図通り終了することを確認するテストを追加
- 手元でテストが正しく動くこと、GitHub Actionsでのテストが正しく動くことを確認

### 手元（Mac）でテストが通ることの確認

```
% make test
bats tests/
Makefile.bats
 ✓ TARGET_DIRの環境変数が設定されていない場合エラーになること

1 test, 0 failures
```

### GitHub Actionsでテストが通ることの確認

https://github.com/blue-goheimochi/php-metrics-tools/actions/runs/7592571207/job/20682065987#step:4:7

```
bats tests/
1..1
ok 1 TARGET_DIRの環境変数が設定されていない場合エラーになること
```

## Ubuntuのテストケース(matrix)を追加

Ubuntuでもテストをするようにymlファイルのmatrixを追加した。

### GitHub Actionsでテストが通らないことを確認

https://github.com/blue-goheimochi/php-metrics-tools/actions/runs/7592585679/job/20682099177#step:4:11

```
bats tests/
1..1
not ok 1 TARGET_DIRの環境変数が設定されていない場合エラーになること
# (in test file tests/Makefile.bats, line 7)
#   `[ "$status" -ne 0 ]' failed
make: *** [Makefile:6[5](https://github.com/blue-goheimochi/php-metrics-tools/actions/runs/7592585679/job/20682099177#step:4:6): test] Error 1
Error: Process completed with exit code 2.
```

### Ubuntu環境でテストが通らないことを確認

```
ubuntu@ip-xxx-xx-xx-xxx:~/php-metrics-tools$ make test
bats tests/
 ✗ TARGET_DIRの環境変数が設定されていない場合エラーになること
   (in test file tests/Makefile.bats, line 7)
     `[ "$status" -ne 0 ]' failed

1 test, 1 failure

make: *** [Makefile:65: test] Error 1
```

`make check` コマンドを打った結果もこんな感じ。

```
ubuntu@ip-xxx-xx-xx-xxx:~/php-metrics-tools$ make check
/bin/sh: 1: [[: not found
TARGET_DIR:
```

## 変数の参照をPOSIX互換の記述に修正

変数の参照の仕方を修正。

### GitHub Actionsでテストが通ることを確認

- Mac: https://github.com/blue-goheimochi/php-metrics-tools/actions/runs/7592614145/job/20682167036#step:4:7
- Ubuntu: https://github.com/blue-goheimochi/php-metrics-tools/actions/runs/7592614145/job/20682167123#step:4:7

### 手元（Mac）でテストが通ることの確認

```
% make test
bats tests/
Makefile.bats
 ✓ TARGET_DIRの環境変数が設定されていない場合エラーになること

1 test, 0 failures
```

### Ubuntu環境でテストが通ることの確認

```
ubuntu@ip-xxx-xx-xx-xxx:~/php-metrics-tools$ make test
bats tests/
 ✓ TARGET_DIRの環境変数が設定されていない場合エラーになること 

1 test, 0 failures
```

-----

@smeghead さん、ご報告ありがとうございました！！！！！ 🙏 🙏 🙏 